### PR TITLE
Improve frequency analysis

### DIFF
--- a/src/Monoalphabetische.Substitution/Analyse.cs
+++ b/src/Monoalphabetische.Substitution/Analyse.cs
@@ -1,27 +1,23 @@
-﻿namespace Monoalphabetische.Substitution;
+namespace Monoalphabetische.Substitution;
 
 public static class Analyse
 {
-    private static List<Letter> alphabeth = new List<Letter>()
+    private static List<Letter> alphabeth = MessageHelper.Alphabeth
+        .Select(c => new Letter(c)).ToList();
+
+    private static void ResetCounters()
     {
-        new Letter('A'), new Letter('B'), new Letter('C'),
-        new Letter('D'), new Letter('E'), new Letter('F'),
-        new Letter('G'), new Letter('H'), new Letter('I'),
-        new Letter('J'), new Letter('K'), new Letter('L'),
-        new Letter('M'), new Letter('N'), new Letter('O'),
-        new Letter('P'), new Letter('Q'), new Letter('R'),
-        new Letter('S'), new Letter('T'), new Letter('U'),
-        new Letter('V'), new Letter('W'), new Letter('X'),
-        new Letter('Y'), new Letter('Z'), new Letter(' '),
-        new Letter(','), new Letter('.')
-    };
+        foreach(var letter in alphabeth)
+        {
+            letter.Counter = 0;
+        }
+    }
 
     private static void CountCharacters(string message)
     {
         foreach(char character in message)
         {
-            Letter? letter = alphabeth.Where(letter => letter.Value == character).FirstOrDefault();
-
+            Letter? letter = alphabeth.FirstOrDefault(l => l.Value == character);
             if(letter != null)
             {
                 letter.Counter++;
@@ -31,19 +27,18 @@ public static class Analyse
 
     public static void AnalyseMessage(string message)
     {
+        if(message.Length < 30)
+        {
+            Console.WriteLine("Warning: Very short message - frequency analysis may be inaccurate.");
+        }
+
+        ResetCounters();
         CountCharacters(message);
         alphabeth = alphabeth.OrderByDescending(letter => letter.Counter).ToList();
 
         int indexMostCommonLetter = Array.IndexOf(MessageHelper.Alphabeth, alphabeth[0].Value);
         int indexLetterE = Array.IndexOf(MessageHelper.Alphabeth, 'E');
-
-        if(indexMostCommonLetter > indexLetterE)
-        {
-            Console.WriteLine($"Possible Key: { indexMostCommonLetter - indexLetterE }");
-        }
-        else if(indexLetterE > indexMostCommonLetter)
-        {
-            Console.WriteLine($"Possible Key: { indexLetterE - indexMostCommonLetter }");
-        }
+        int possibleKey = Math.Abs(indexMostCommonLetter - indexLetterE);
+        Console.WriteLine($"Possible Key: { possibleKey }");
     }
 }

--- a/src/Monoalphabetische.Substitution/Decrypt.cs
+++ b/src/Monoalphabetische.Substitution/Decrypt.cs
@@ -6,7 +6,7 @@ public static class Decrypt
 { 
     public static void _Decrypt(Message message)
     {
-        if (message.IsValid == false)
+        if (!message.IsValid)
         {
             throw new ArgumentException("Message is invalid. Maybe the encrypted/decrypted message contains an unsupported character or an unsupported key.");
         }

--- a/src/Monoalphabetische.Substitution/Encrypt.cs
+++ b/src/Monoalphabetische.Substitution/Encrypt.cs
@@ -6,7 +6,7 @@ public static class Encrypt
 {
     public static void _Encrypt(Message message)
     {
-        if(message.IsValid == false)
+        if (!message.IsValid)
         {
             throw new ArgumentException("Message is invalid. Maybe the encrypted/decrypted message contains an unsupported character or an unsupported key.");
         }

--- a/src/Monoalphabetische.Substitution/MessageHelper.cs
+++ b/src/Monoalphabetische.Substitution/MessageHelper.cs
@@ -13,17 +13,17 @@ public static class MessageHelper
 
     public static bool IsValid(Message message)
     {
-        if(_isMessageValid(message.EncryptedMessage) == false)
+        if (!_isMessageValid(message.EncryptedMessage))
         {
             return false;
         }
 
-        if(_isMessageValid(message.DecryptedMessagae) == false)
+        if (!_isMessageValid(message.DecryptedMessagae))
         {
             return false;
         }
 
-        if(_isKeyValid(message.Key) == false)
+        if (!_isKeyValid(message.Key))
         {
             return false;
         }
@@ -38,7 +38,7 @@ public static class MessageHelper
         bool isValid = true;
         foreach (char character in message)
         {
-            if (Alphabeth.Contains(character) == false)
+            if (!Alphabeth.Contains(character))
             {
                 return false;
             }
@@ -50,6 +50,6 @@ public static class MessageHelper
     private static bool _isKeyValid(int? key)
     {
         if (key == null) return true;
-        return key >= Alphabeth.Length ? false : true;
+        return !(key >= Alphabeth.Length);
     }
 }


### PR DESCRIPTION
## Summary
- reset character counters before each analysis
- warn if the input text is very short
- use the main alphabet when counting characters

## Testing
- `dotnet build src/Monoalphabetische.Substitution` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484545cbd48320807248dd7c0a2f2a