### PR TITLE
Enable CLI parsing with System.CommandLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ option `--skip-input` disables all prompts entirely. Modes `E` (Encrypt) and `D`
 (Decrypt) require a key. In mode `G` the key is determined by frequency analysis
 of the encrypted text and may therefore be omitted.
 
-The command line options are parsed using `System.CommandLine` and validated
+The command line options are parsed using `CommandLineParser` and validated
 with `FluentValidation`.

--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ option `--skip-input` disables all prompts entirely. Modes `E` (Encrypt) and `D`
 (Decrypt) require a key. In mode `G` the key is determined by frequency analysis
 of the encrypted text and may therefore be omitted.
 
-The command line options are parsed using `CommandLineParser` and validated
+The command line options are parsed using `System.CommandLine` and validated
 with `FluentValidation`.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,28 @@
-# Monoalphabetische Substitution
+# Monoalphabetic Substitution
 
-Die Anwendung besteht aus einer Bibliothek **Monoalphabetische.Application** mit der eigentlichen Verschlüsselungslogik und einem Konsolenprogramm **Monoalphabetische.Cli**. Nachrichten lassen sich damit sowohl verschlüsseln als auch entschlüsseln.
+This repository contains the library **Monoalphabetische.Application** with the
+core encryption logic and the console application **Monoalphabetische.Cli**. It
+allows you to encrypt and decrypt messages using a simple substitution cipher.
 
-## Kompilieren
-Voraussetzung für das Bauen und Ausführen ist das .NET SDK (Version 9.0 oder neuer). Das Projekt wird aus dem Repository-Verzeichnis heraus kompiliert:
+## Build
+To build and run the solution you need the .NET SDK (version 9.0 or newer). Run
+the following command from the repository root:
 
 ```bash
 dotnet build src/Monoalphabetische.sln
 ```
 
-## Ausführen
-Die Anwendung starten Sie mit:
+## Usage
+Launch the program with:
 
 ```bash
-dotnet run --project src/Monoalphabetische.Cli
+dotnet run --project src/Monoalphabetische.Cli -- [--message <text>] [--key <number>] [--mode <E|D|G>] [--skip-input]
 ```
 
-Beim Start fragt das Programm nach der Nachricht, dem Schlüssel und dem Modus (Verschlüsselung oder Entschlüsselung) und zeigt das Ergebnis im Anschluss an.
+Providing `--message`, `--key` and `--mode` skips the interactive prompts. The
+option `--skip-input` disables all prompts entirely. Modes `E` (Encrypt) and `D`
+(Decrypt) require a key. In mode `G` the key is determined by frequency analysis
+of the encrypted text and may therefore be omitted.
+
+The command line options are parsed using `System.CommandLine` and validated
+with `FluentValidation`.

--- a/src/Monoalphabetische.Application/Analyse.cs
+++ b/src/Monoalphabetische.Application/Analyse.cs
@@ -25,7 +25,7 @@ public static class Analyse
         }
     }
 
-    public static void AnalyseMessage(string message)
+    public static int GuessKey(string message)
     {
         if(message.Length < 30)
         {
@@ -39,6 +39,12 @@ public static class Analyse
         int indexMostCommonLetter = Array.IndexOf(MessageHelper.Alphabeth, alphabeth[0].Value);
         int indexLetterE = Array.IndexOf(MessageHelper.Alphabeth, 'E');
         int possibleKey = Math.Abs(indexMostCommonLetter - indexLetterE);
+        return possibleKey;
+    }
+
+    public static void AnalyseMessage(string message)
+    {
+        int possibleKey = GuessKey(message);
         Console.WriteLine($"Possible Key: { possibleKey }");
     }
 }

--- a/src/Monoalphabetische.Application/Decrypt.cs
+++ b/src/Monoalphabetische.Application/Decrypt.cs
@@ -13,12 +13,12 @@ public static class Decrypt
 
         if (string.IsNullOrWhiteSpace(message.EncryptedMessage))
         {
-            throw new ArgumentException("Can't encrypt message because there is no decrypted message defined.");
+            throw new ArgumentException("Can't decrypt message because there is no encrypted message defined.");
         }
 
         if (message.Key == null)
         {
-            throw new ArgumentException("Can't encrypt message because there is not key given.");
+            throw new ArgumentException("Can't decrypt message because there is no key given.");
         }
 
         StringBuilder stringBuilder = new StringBuilder();
@@ -28,7 +28,7 @@ public static class Decrypt
             stringBuilder.Append(MessageHelper.Alphabeth[index]);
         }
 
-        message.DecryptedMessagae = stringBuilder.ToString();
+        message.DecryptedMessage = stringBuilder.ToString();
     }
 
     private static int getNewAlphabethIndex(char character, int key)

--- a/src/Monoalphabetische.Application/Encrypt.cs
+++ b/src/Monoalphabetische.Application/Encrypt.cs
@@ -11,18 +11,18 @@ public static class Encrypt
             throw new ArgumentException("Message is invalid. Maybe the encrypted/decrypted message contains an unsupported character or an unsupported key.");
         }
 
-        if(string.IsNullOrWhiteSpace(message.DecryptedMessagae))
+        if(string.IsNullOrWhiteSpace(message.DecryptedMessage))
         {
             throw new ArgumentException("Can't encrypt message because there is no decrypted message defined.");
         }
 
         if(message.Key == null)
         {
-            throw new ArgumentException("Can't encrypt message because there is not key given.");
+            throw new ArgumentException("Can't encrypt message because there is no key given.");
         }
 
         StringBuilder stringBuilder = new StringBuilder();
-        foreach (char character in message.DecryptedMessagae) 
+        foreach (char character in message.DecryptedMessage)
         {
             int index = getNewAlphabethIndex(character, Convert.ToInt32(message.Key));
             stringBuilder.Append(MessageHelper.Alphabeth[index]);

--- a/src/Monoalphabetische.Application/Message.cs
+++ b/src/Monoalphabetische.Application/Message.cs
@@ -16,9 +16,10 @@ public class Message
             }
         }
     }
-    public string? DecryptedMessagae {
+    public string? DecryptedMessage
+    {
         get { return _decryptedMessage; }
-        set 
+        set
         {
             if (value != null)
             {

--- a/src/Monoalphabetische.Application/MessageHelper.cs
+++ b/src/Monoalphabetische.Application/MessageHelper.cs
@@ -18,7 +18,7 @@ public static class MessageHelper
             return false;
         }
 
-        if (!_isMessageValid(message.DecryptedMessagae))
+        if (!_isMessageValid(message.DecryptedMessage))
         {
             return false;
         }

--- a/src/Monoalphabetische.Application/SubstitutionService.cs
+++ b/src/Monoalphabetische.Application/SubstitutionService.cs
@@ -15,4 +15,12 @@ public class SubstitutionService
         Application.Decrypt.Process(msg);
         return msg;
     }
+
+    public Message DecryptWithGuessedKey(string message)
+    {
+        int key = Analyse.GuessKey(message);
+        var msg = new Message { Key = key, EncryptedMessage = message };
+        Application.Decrypt.Process(msg);
+        return msg;
+    }
 }

--- a/src/Monoalphabetische.Application/SubstitutionService.cs
+++ b/src/Monoalphabetische.Application/SubstitutionService.cs
@@ -4,7 +4,7 @@ public class SubstitutionService
 {
     public Message Encrypt(int key, string message)
     {
-        var msg = new Message { Key = key, DecryptedMessagae = message };
+        var msg = new Message { Key = key, DecryptedMessage = message };
         Application.Encrypt.Process(msg);
         return msg;
     }

--- a/src/Monoalphabetische.Cli/CliOptionsValidator.cs
+++ b/src/Monoalphabetische.Cli/CliOptionsValidator.cs
@@ -1,0 +1,24 @@
+﻿using FluentValidation;
+
+namespace Monoalphabetische.Cli;
+
+public partial class Program
+{
+    private sealed class CliOptionsValidator : AbstractValidator<CliOptions>
+    {
+        public CliOptionsValidator()
+        {
+            RuleFor(x => x.Message)
+                .NotEmpty().WithMessage("Message is required.");
+
+            RuleFor(x => x.Mode)
+                .Must(m => m == "E" || m == "D" || m == "G")
+                .WithMessage("Mode must be E, D or G.");
+
+            When(x => x.Mode == "E" || x.Mode == "D", () =>
+            {
+                RuleFor(x => x.Key).NotNull().WithMessage("Key is required when mode is E or D.");
+            });
+        }
+    }
+}

--- a/src/Monoalphabetische.Cli/Monoalphabetische.Cli.csproj
+++ b/src/Monoalphabetische.Cli/Monoalphabetische.Cli.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Monoalphabetische.Cli/Monoalphabetische.Cli.csproj
+++ b/src/Monoalphabetische.Cli/Monoalphabetische.Cli.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Monoalphabetische.Application\Monoalphabetische.Application.csproj" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="FluentValidation" Version="11.7.0" />
   </ItemGroup>
 

--- a/src/Monoalphabetische.Cli/Monoalphabetische.Cli.csproj
+++ b/src/Monoalphabetische.Cli/Monoalphabetische.Cli.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Monoalphabetische.Application\Monoalphabetische.Application.csproj" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0" />
+    <PackageReference Include="FluentValidation" Version="11.7.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Monoalphabetische.Cli/Monoalphabetische.Cli.csproj
+++ b/src/Monoalphabetische.Cli/Monoalphabetische.Cli.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Monoalphabetische.Application\Monoalphabetische.Application.csproj" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="FluentValidation" Version="11.7.0" />
+    <PackageReference Include="FluentValidation" Version="12.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Monoalphabetische.Cli/Program.cs
+++ b/src/Monoalphabetische.Cli/Program.cs
@@ -1,10 +1,9 @@
-using FluentValidation;
 using Monoalphabetische.Application;
 using CommandLine;
 
 namespace Monoalphabetische.Cli;
 
-public class Program
+public partial class Program
 {
     public static int Main(string[] args)
     {
@@ -92,7 +91,7 @@ public class Program
             Console.WriteLine(e.Message);
         }
 
-        if (result != null && !string.IsNullOrWhiteSpace(result.EncryptedMessage))
+        if (result != null && !string.IsNullOrWhiteSpace(result.EncryptedMessage) && options.Mode == "G")
         {
             Analyse.AnalyseMessage(result.EncryptedMessage);
         }
@@ -111,23 +110,5 @@ public class Program
 
         [Option("skip-input", HelpText = "Skip interactive input")]
         public bool SkipInput { get; set; }
-    }
-
-    private class CliOptionsValidator : AbstractValidator<CliOptions>
-    {
-        public CliOptionsValidator()
-        {
-            RuleFor(x => x.Message)
-                .NotEmpty().WithMessage("Message is required.");
-
-            RuleFor(x => x.Mode)
-                .Must(m => m == "E" || m == "D" || m == "G")
-                .WithMessage("Mode must be E, D or G.");
-
-            When(x => x.Mode == "E" || x.Mode == "D", () =>
-            {
-                RuleFor(x => x.Key).NotNull().WithMessage("Key is required when mode is E or D.");
-            });
-        }
     }
 }

--- a/src/Monoalphabetische.Cli/Program.cs
+++ b/src/Monoalphabetische.Cli/Program.cs
@@ -1,10 +1,28 @@
 using Monoalphabetische.Application;
-using CommandLine;
+using System.CommandLine;
 
 namespace Monoalphabetische.Cli;
 
-public partial class Program
-{
+        var messageOption = new Option<string?>("--message", "Message to encrypt or decrypt");
+        var keyOption = new Option<int?>("--key", () => null, "Key for the substitution");
+        var modeOption = new Option<string?>("--mode", "E=Encrypt, D=Decrypt, G=Guess");
+        var skipInputOption = new Option<bool>("--skip-input", "Skip interactive input");
+
+        var rootCommand = new RootCommand
+        {
+            messageOption,
+            keyOption,
+            modeOption,
+            skipInputOption
+        };
+
+        rootCommand.SetHandler((string? message, int? key, string? mode, bool skipInput) =>
+        {
+            var options = new CliOptions { Message = message, Key = key, Mode = mode, SkipInput = skipInput };
+            Environment.ExitCode = RunWithOptions(options);
+        }, messageOption, keyOption, modeOption, skipInputOption);
+
+        return rootCommand.Invoke(args);
     public static int Main(string[] args)
     {
         return Parser.Default.ParseArguments<CliOptions>(args)
@@ -77,13 +95,13 @@ public partial class Program
             else if (options.Mode == "D")
             {
                 result = service.Decrypt(options.Key!.Value, options.Message!);
-                Console.WriteLine($"Decrypted text: {result.DecryptedMessagae}");
+                Console.WriteLine($"Decrypted text: {result.DecryptedMessage}");
             }
             else if (options.Mode == "G")
             {
                 result = service.DecryptWithGuessedKey(options.Message!);
                 Console.WriteLine($"Guessed Key: {result.Key}");
-                Console.WriteLine($"Decrypted text: {result.DecryptedMessagae}");
+                Console.WriteLine($"Decrypted text: {result.DecryptedMessage}");
             }
         }
         catch (ArgumentException e)
@@ -101,16 +119,9 @@ public partial class Program
 
     private class CliOptions
     {
-        [Option("message", HelpText = "Message to encrypt or decrypt")]
         public string? Message { get; set; }
-
-        [Option("key", HelpText = "Key for the substitution")]
         public int? Key { get; set; }
-
-        [Option("mode", HelpText = "E=Encrypt, D=Decrypt, G=Guess")]
         public string? Mode { get; set; }
-
-        [Option("skip-input", HelpText = "Skip interactive input")]
         public bool SkipInput { get; set; }
     }
 }

--- a/src/Monoalphabetische.Cli/Program.cs
+++ b/src/Monoalphabetische.Cli/Program.cs
@@ -1,47 +1,104 @@
+using FluentValidation;
 using Monoalphabetische.Application;
+using System.CommandLine;
 
 namespace Monoalphabetische.Cli;
 
 public class Program
 {
-    public static void Main(string[] args)
+    public static int Main(string[] args)
     {
-        string? mode = null;
-        string? message = null;
-        int key = -1;
+        var messageOption = new Option<string?>("--message", "Message to encrypt or decrypt");
+        var keyOption = new Option<int?>("--key", () => null, "Key for the substitution");
+        var modeOption = new Option<string?>("--mode", "E=Encrypt, D=Decrypt, G=Guess");
+        var skipInputOption = new Option<bool>("--skip-input", "Skip interactive input");
+
+        var root = new RootCommand("Monoalphabetic Substitution");
+        root.AddOption(messageOption);
+        root.AddOption(keyOption);
+        root.AddOption(modeOption);
+        root.AddOption(skipInputOption);
+
+        root.SetHandler((string? message, int? key, string? mode, bool skipInput) =>
+        {
+            var options = new CliOptions
+            {
+                Message = message,
+                Key = key,
+                Mode = mode,
+                SkipInput = skipInput
+            };
+            var validator = new CliOptionsValidator();
+            var result = validator.Validate(options);
+
+            if (!skipInput)
+            {
+                while (!result.IsValid)
+                {
+                    foreach (var error in result.Errors)
+                    {
+                        Console.WriteLine(error.ErrorMessage);
+                    }
+
+                    if (string.IsNullOrWhiteSpace(options.Message))
+                    {
+                        Console.Write("Enter Message: ");
+                        options.Message = Console.ReadLine();
+                    }
+                    if (string.IsNullOrWhiteSpace(options.Mode) || !(options.Mode == "E" || options.Mode == "D" || options.Mode == "G"))
+                    {
+                        Console.Write("Select mode Encrypt (E), Decrypt (D) or Guess (G): ");
+                        options.Mode = Console.ReadLine()?.ToUpperInvariant();
+                    }
+                    if ((options.Mode == "E" || options.Mode == "D") && options.Key == null)
+                    {
+                        Console.Write("Enter Key: ");
+                        if (int.TryParse(Console.ReadLine(), out var parsedKey))
+                        {
+                            options.Key = parsedKey;
+                        }
+                    }
+                    result = validator.Validate(options);
+                }
+            }
+            else if (!result.IsValid)
+            {
+                foreach (var error in result.Errors)
+                {
+                    Console.WriteLine(error.ErrorMessage);
+                }
+                return;
+            }
+
+            Execute(options);
+        }, messageOption, keyOption, modeOption, skipInputOption);
+
+        return root.Invoke(args);
+    }
+
+    private static void Execute(CliOptions options)
+    {
         var service = new SubstitutionService();
         Message? result = null;
 
-        while (string.IsNullOrWhiteSpace(message))
-        {
-            Console.Write("Enter Message: ");
-            message = Console.ReadLine();
-        }
-
-        while (key == -1)
-        {
-            Console.Write("Enter Key: ");
-            int.TryParse(Console.ReadLine(), out key);
-        }
-
-        while (mode != "E" && mode != "D")
-        {
-            Console.Write("Do you want to Encrypt (E) or Decrypt (D): ");
-            mode = Console.ReadLine();
-        }
-
-        Console.WriteLine($"Input text: {message.ToUpper()}");
+        Console.WriteLine($"Input text: {options.Message!.ToUpper()}");
 
         try
         {
-            if (mode == "E")
+            if (options.Mode == "E")
             {
-                result = service.Encrypt(key, message);
+                result = service.Encrypt(options.Key!.Value, options.Message!);
                 Console.WriteLine($"Encrypted text: {result.EncryptedMessage}");
             }
-            else if (mode == "D")
+            else if (options.Mode == "D")
             {
-                result = service.Decrypt(key, message);
+                result = service.Decrypt(options.Key!.Value, options.Message!);
+                Console.WriteLine($"Decrypted text: {result.DecryptedMessagae}");
+            }
+            else if (options.Mode == "G")
+            {
+                result = service.DecryptWithGuessedKey(options.Message!);
+                Console.WriteLine($"Guessed Key: {result.Key}");
                 Console.WriteLine($"Decrypted text: {result.DecryptedMessagae}");
             }
         }
@@ -53,6 +110,32 @@ public class Program
         if (result != null && !string.IsNullOrWhiteSpace(result.EncryptedMessage))
         {
             Analyse.AnalyseMessage(result.EncryptedMessage);
+        }
+    }
+
+    private class CliOptions
+    {
+        public string? Message { get; set; }
+        public int? Key { get; set; }
+        public string? Mode { get; set; }
+        public bool SkipInput { get; set; }
+    }
+
+    private class CliOptionsValidator : AbstractValidator<CliOptions>
+    {
+        public CliOptionsValidator()
+        {
+            RuleFor(x => x.Message)
+                .NotEmpty().WithMessage("Message is required.");
+
+            RuleFor(x => x.Mode)
+                .Must(m => m == "E" || m == "D" || m == "G")
+                .WithMessage("Mode must be E, D or G.");
+
+            When(x => x.Mode == "E" || x.Mode == "D", () =>
+            {
+                RuleFor(x => x.Key).NotNull().WithMessage("Key is required when mode is E or D.");
+            });
         }
     }
 }

--- a/src/Monoalphabetische.Cli/Program.cs
+++ b/src/Monoalphabetische.Cli/Program.cs
@@ -91,7 +91,9 @@ public partial class Program
             Console.WriteLine(e.Message);
         }
 
-        if (result != null && !string.IsNullOrWhiteSpace(result.EncryptedMessage) && options.Mode == "G")
+        if (options.Mode == "G" &&
+            result != null &&
+            !string.IsNullOrWhiteSpace(result.EncryptedMessage))
         {
             Analyse.AnalyseMessage(result.EncryptedMessage);
         }


### PR DESCRIPTION
## Summary
- parse CLI parameters with System.CommandLine
- validate options using FluentValidation
- document features in English
- translate CLI messages to English

## Testing
- `dotnet build src/Monoalphabetische.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684853ebf5e483209a6f5cd3e8a9dfb9