### PR TITLE
Expand charset

### DIFF
--- a/src/Monoalphabetische.Application/Analyse.cs
+++ b/src/Monoalphabetische.Application/Analyse.cs
@@ -2,7 +2,7 @@ namespace Monoalphabetische.Application;
 
 public static class Analyse
 {
-    // Counter for each possible character value
+    // Counter for each printable character defined in MessageHelper
     private static readonly int[] counters = new int[MessageHelper.CharsetSize];
 
     private static void ResetCounters()
@@ -14,7 +14,11 @@ public static class Analyse
     {
         foreach(char character in message)
         {
-            counters[character]++;
+            int index = Array.IndexOf(MessageHelper.Alphabeth, character);
+            if (index >= 0)
+            {
+                counters[index]++;
+            }
         }
     }
 
@@ -37,7 +41,7 @@ public static class Analyse
             }
         }
 
-        int indexLetterE = 'E';
+        int indexLetterE = Array.IndexOf(MessageHelper.Alphabeth, 'E');
         int possibleKey = Math.Abs(indexMostCommonLetter - indexLetterE);
         return possibleKey;
     }

--- a/src/Monoalphabetische.Application/Analyse.cs
+++ b/src/Monoalphabetische.Application/Analyse.cs
@@ -2,26 +2,19 @@ namespace Monoalphabetische.Application;
 
 public static class Analyse
 {
-    private static List<Letter> alphabeth = MessageHelper.Alphabeth
-        .Select(c => new Letter(c)).ToList();
+    // Counter for each possible character value
+    private static readonly int[] counters = new int[MessageHelper.CharsetSize];
 
     private static void ResetCounters()
     {
-        foreach(var letter in alphabeth)
-        {
-            letter.Counter = 0;
-        }
+        Array.Clear(counters, 0, counters.Length);
     }
 
     private static void CountCharacters(string message)
     {
         foreach(char character in message)
         {
-            Letter? letter = alphabeth.FirstOrDefault(l => l.Value == character);
-            if(letter != null)
-            {
-                letter.Counter++;
-            }
+            counters[character]++;
         }
     }
 
@@ -34,10 +27,17 @@ public static class Analyse
 
         ResetCounters();
         CountCharacters(message);
-        alphabeth = alphabeth.OrderByDescending(letter => letter.Counter).ToList();
 
-        int indexMostCommonLetter = Array.IndexOf(MessageHelper.Alphabeth, alphabeth[0].Value);
-        int indexLetterE = Array.IndexOf(MessageHelper.Alphabeth, 'E');
+        int indexMostCommonLetter = 0;
+        for (int i = 1; i < counters.Length; i++)
+        {
+            if (counters[i] > counters[indexMostCommonLetter])
+            {
+                indexMostCommonLetter = i;
+            }
+        }
+
+        int indexLetterE = 'E';
         int possibleKey = Math.Abs(indexMostCommonLetter - indexLetterE);
         return possibleKey;
     }

--- a/src/Monoalphabetische.Application/Decrypt.cs
+++ b/src/Monoalphabetische.Application/Decrypt.cs
@@ -33,7 +33,7 @@ public static class Decrypt
 
     private static int getNewAlphabethIndex(char character, int key)
     {
-        int baseIndex = character;
+        int baseIndex = Array.IndexOf(MessageHelper.Alphabeth, character);
         int newIndex = baseIndex - key;
 
         if (newIndex < 0)

--- a/src/Monoalphabetische.Application/Decrypt.cs
+++ b/src/Monoalphabetische.Application/Decrypt.cs
@@ -33,12 +33,12 @@ public static class Decrypt
 
     private static int getNewAlphabethIndex(char character, int key)
     {
-        int baseIndex = Array.IndexOf(MessageHelper.Alphabeth, character);
+        int baseIndex = character;
         int newIndex = baseIndex - key;
 
         if (newIndex < 0)
         {
-            newIndex = MessageHelper.Alphabeth.Length + newIndex;
+            newIndex = MessageHelper.CharsetSize + newIndex;
         }
 
         return newIndex;

--- a/src/Monoalphabetische.Application/Encrypt.cs
+++ b/src/Monoalphabetische.Application/Encrypt.cs
@@ -33,7 +33,7 @@ public static class Encrypt
 
     private static int getNewAlphabethIndex(char character, int key)
     {
-        int baseIndex = character;
+        int baseIndex = Array.IndexOf(MessageHelper.Alphabeth, character);
         int newIndex = baseIndex + key;
 
         if (newIndex >= MessageHelper.CharsetSize)

--- a/src/Monoalphabetische.Application/Encrypt.cs
+++ b/src/Monoalphabetische.Application/Encrypt.cs
@@ -33,12 +33,12 @@ public static class Encrypt
 
     private static int getNewAlphabethIndex(char character, int key)
     {
-        int baseIndex = Array.IndexOf(MessageHelper.Alphabeth, character);
+        int baseIndex = character;
         int newIndex = baseIndex + key;
 
-        if (newIndex >= MessageHelper.Alphabeth.Length)
+        if (newIndex >= MessageHelper.CharsetSize)
         {
-            newIndex -= MessageHelper.Alphabeth.Length;
+            newIndex -= MessageHelper.CharsetSize;
         }
 
         return newIndex;

--- a/src/Monoalphabetische.Application/MessageHelper.cs
+++ b/src/Monoalphabetische.Application/MessageHelper.cs
@@ -1,15 +1,16 @@
+using System.Linq;
 ﻿namespace Monoalphabetische.Application;
 
 public static class MessageHelper
 {
-    public static readonly char[] Alphabeth = new char[] {
-        'A', 'B', 'C', 'D', 'E', 'F', 'G',
-        'H', 'I', 'J', 'K', 'L', 'M', 'N',
-        'O', 'P', 'Q', 'R', 'S', 'T', 'U',
-        'V', 'W', 'X', 'Y', 'Z', '0', '1',
-        '2', '3', '4', '5', '6', '7', '8',
-        '9', ' ', '.', ','
-    };
+    // Contains every UTF-16 code point so we can work with any
+    // character representable in .NET strings.
+    public static readonly char[] Alphabeth = Enumerable
+        .Range(char.MinValue, char.MaxValue + 1)
+        .Select(i => (char)i)
+        .ToArray();
+
+    public static int CharsetSize => Alphabeth.Length;
 
     public static bool IsValid(Message message)
     {
@@ -33,23 +34,13 @@ public static class MessageHelper
 
     private static bool _isMessageValid(string? message)
     {
-        if(message == null) return true;
-
-        bool isValid = true;
-        foreach (char character in message)
-        {
-            if (!Alphabeth.Contains(character))
-            {
-                return false;
-            }
-        }
-
-        return isValid;
+        // Every UTF-16 character is allowed, so any non-null string is valid.
+        return message != null;
     }
 
     private static bool _isKeyValid(int? key)
     {
         if (key == null) return true;
-        return !(key >= Alphabeth.Length);
+        return key >= 0 && key < CharsetSize;
     }
 }

--- a/src/Monoalphabetische.Application/SubstitutionService.cs
+++ b/src/Monoalphabetische.Application/SubstitutionService.cs
@@ -4,14 +4,14 @@ public class SubstitutionService
 {
     public Message Encrypt(int key, string message)
     {
-        var msg = new Message { Key = key, DecryptedMessage = message.ToUpper() };
+        var msg = new Message { Key = key, DecryptedMessage = message };
         Application.Encrypt.Process(msg);
         return msg;
     }
 
     public Message Decrypt(int key, string message)
     {
-        var msg = new Message { Key = key, EncryptedMessage = message.ToUpper() };
+        var msg = new Message { Key = key, EncryptedMessage = message };
         Application.Decrypt.Process(msg);
         return msg;
     }
@@ -19,7 +19,7 @@ public class SubstitutionService
     public Message DecryptWithGuessedKey(string message)
     {
         int key = Analyse.GuessKey(message);
-        var msg = new Message { Key = key, EncryptedMessage = message.ToUpper() };
+        var msg = new Message { Key = key, EncryptedMessage = message };
         Application.Decrypt.Process(msg);
         return msg;
     }

--- a/src/Monoalphabetische.Cli/Program.cs
+++ b/src/Monoalphabetische.Cli/Program.cs
@@ -1,5 +1,6 @@
 using Monoalphabetische.Application;
 using CommandLine;
+using System.Text;
 
 namespace Monoalphabetische.Cli;
 
@@ -7,6 +8,10 @@ public partial class Program
 {
     public static int Main(string[] args)
     {
+        // Ensure UTF-8 encoding so all printable characters can be displayed
+        // correctly even outside the current console code page.
+        Console.OutputEncoding = Encoding.UTF8;
+        Console.InputEncoding = Encoding.UTF8;
         return Parser.Default.ParseArguments<CliOptions>(args)
             .MapResult(RunWithOptions, _ => 1);
     }

--- a/src/Monoalphabetische.Cli/Program.cs
+++ b/src/Monoalphabetische.Cli/Program.cs
@@ -65,7 +65,7 @@ public partial class Program
         var service = new SubstitutionService();
         Message? result = null;
 
-        Console.WriteLine($"Input text: {options.Message!.ToUpper()}");
+        Console.WriteLine($"Input text: {options.Message}");
 
         try
         {


### PR DESCRIPTION
## Summary
- support full UTF-16 range in MessageHelper
- adjust encryption and decryption to use new charset
- avoid uppercasing messages
- update frequency analysis implementation

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491c94e4a08320bc14459c71b72197